### PR TITLE
Add include relative to current file.

### DIFF
--- a/src/aleppo.erl
+++ b/src/aleppo.erl
@@ -286,7 +286,9 @@ expand_filename([$$|FileNameMinusDollar] = FileName, Context) ->
 expand_filename(FileName, Context) ->
     expand_relative_filename(FileName, Context).
 
-expand_relative_filename(FileName, Context) ->
+expand_relative_filename(FileName, #ale_context{include_trail = IncTrail,
+                                                include_dirs = IncDirs}) ->
+    TrailDirs = [filename:dirname(Trail) || Trail <- IncTrail],
     ExpandedFileName = lists:foldl(
         fun
             (Dir, "") ->
@@ -297,7 +299,7 @@ expand_relative_filename(FileName, Context) ->
                 end;
             (_, F) ->
                 F
-        end, "", Context#ale_context.include_dirs),
+        end, "", IncDirs ++ TrailDirs),
     case ExpandedFileName of
         "" -> throw({error, {not_found, FileName}});
         ExpandedFileName ->


### PR DESCRIPTION
Erlang docs http://erlang.org/doc/man/erlc.html are saying:

> When encountering an -include or -include_lib directive, the compiler searches for header files in the following directories:
> * ".", the current working directory of the file server
> * The base name of the compiled file
> * The directories specified using option -I; the directory specified last is searched first

Here we implementing 2nd option for recursive includes (include inside another include)

```
$ tree
app1
- src
-- my_file.erl
app2
- include
-- my_header1.hrl
-- my_header2.hrl

$ cat app1/src/my_file.erl
-include_lib("app2/include/my_header1.hrl").

$ cat app2/include/my_header1.hrl
-include("my_header2").

$ cat app2/include/my_header2.hrl
-define(...).
```

