### PR TITLE
MODULE_NAME instead of MODULE_STRING

### DIFF
--- a/src/aleppo.erl
+++ b/src/aleppo.erl
@@ -54,7 +54,7 @@ process_tree(ParseTree, Options) ->
                 undefined -> Dict0;
                 Module ->
                     dict:store('MODULE', [{atom, 1, Module}],
-                               dict:store('MODULE_NAME',
+                               dict:store('MODULE_STRING',
                                           [{string, 1, atom_to_list(Module)}],
                                           Dict0))
             end,


### PR DESCRIPTION
`aleppo:process_tree/2` contemplates the existence of `?MODULE` and `?MODULE_NAME`, but this second one is a bug since the proper macro is `?MODULE_STRING`.